### PR TITLE
Session groups

### DIFF
--- a/id/id.go
+++ b/id/id.go
@@ -3,7 +3,7 @@ package id
 import (
 	"crypto/rand"
 	"database/sql/driver"
-	"encoding/base32"
+	"encoding/hex"
 	"errors"
 )
 
@@ -39,17 +39,17 @@ func (id *ID) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-// MarshalText returns a base32-encoded slice of bytes.
+// MarshalText returns a hex-encoded slice of bytes.
 func (id ID) MarshalText() (text []byte, err error) {
-	data := make([]byte, base32.StdEncoding.EncodedLen(len(id)))
-	base32.StdEncoding.Encode(data, id[:])
+	data := make([]byte, hex.EncodedLen(len(id)))
+	hex.Encode(data, id[:])
 	return data, nil
 }
 
-// UnmarshalText sets the value of the ID based on a base32-encoded slice of bytes.
+// UnmarshalText sets the value of the ID based on a hex-encoded slice of bytes.
 func (id *ID) UnmarshalText(text []byte) error {
-	data := make([]byte, base32.StdEncoding.DecodedLen(len(text)))
-	if _, err := base32.StdEncoding.Decode(data, text); err != nil {
+	data := make([]byte, hex.DecodedLen(len(text)))
+	if _, err := hex.Decode(data, text); err != nil {
 		return err
 	}
 
@@ -58,7 +58,7 @@ func (id *ID) UnmarshalText(text []byte) error {
 
 // String returns a hex-encoded string.
 func (id ID) String() string {
-	return base32.StdEncoding.EncodeToString(id[:])
+	return hex.EncodeToString(id[:])
 }
 
 // Scan sets the value of the ID based on an interface.

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/O-C-R/auth/id"
+	"github.com/garyburd/redigo/redis"
 )
 
 func TestSession(t *testing.T) {
@@ -16,8 +17,10 @@ func TestSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sessionID, err := id.New()
-	if err != nil {
+	conn := sessionStore.pool.Get()
+	defer conn.Close()
+
+	if _, err := conn.Do("FLUSHDB"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -26,20 +29,112 @@ func TestSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := sessionStore.SetSession(sessionID, userID); err != nil {
+	sessionID1, err := id.New()
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	var returnedUserID id.ID
-	if err := sessionStore.Session(sessionID, &returnedUserID); err != nil {
+	if err := sessionStore.SetSession(sessionID1, userID, "1"); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID2, err := id.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sessionStore.SetSession(sessionID2, userID, "2"); err != nil {
+		t.Fatal(err)
+	}
+
+	var returnedUserID string
+	if err := sessionStore.Session(sessionID1, &returnedUserID); err != nil {
 		t.Error(err)
 	}
 
-	if returnedUserID != userID {
-		t.Errorf("incorrect user ID, %s, expected %s", returnedUserID, userID)
+	if returnedUserID != "1" {
+		t.Errorf("incorrect user ID, %s, expected %s", returnedUserID, "1")
 	}
 
-	if err := sessionStore.DeleteSession(sessionID); err != nil {
+	// TODO: get group key some other way
+	groupKey := "g" + userID.String()
+
+	res, err := redis.Strings(conn.Do("ZRANGE", groupKey, 0, -1))
+	if err != nil {
+		t.Error(err)
+	}
+	if len(res) != 2 {
+		t.Errorf("Expected 2 sessions in group, got %d: %v", len(res), res)
+	}
+
+	if err := sessionStore.DeleteSession(sessionID1); err != nil {
 		t.Fatal(err)
+	}
+
+	res, err = redis.Strings(conn.Do("ZRANGE", groupKey, 0, -1))
+	if err != nil {
+		t.Error(err)
+	}
+	if len(res) != 1 {
+		t.Errorf("Expected 1 sessions in group, got %d: %v", len(res), res)
+	}
+
+	if err := sessionStore.Session(sessionID2, &returnedUserID); err != nil {
+		t.Error(err)
+	}
+
+	if returnedUserID != "2" {
+		t.Errorf("incorrect user ID, %s, expected %s", returnedUserID, "2")
+	}
+
+	if err := sessionStore.InvalidateSessions(userID); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCappedSessions(t *testing.T) {
+	sessionStore, err := NewSessionStore(SessionStoreOptions{
+		Addr:            ":6379",
+		SessionDuration: time.Second,
+		MaxSessions:     5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn := sessionStore.pool.Get()
+	defer conn.Close()
+
+	if _, err := conn.Do("FLUSHDB"); err != nil {
+		t.Fatal(err)
+	}
+
+	userID, err := id.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		sessionID, err := id.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := sessionStore.SetSession(sessionID, userID, userID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// TODO: get the group key some other way
+	res, err := redis.Strings(conn.Do("ZRANGE", "g"+userID.String(), 0, -1))
+	if err != nil {
+		t.Error(err)
+	}
+	if len(res) != 5 {
+		t.Errorf("Expected 5 sessions in group, got %d: %v", len(res), res)
+	}
+
+	if err := sessionStore.InvalidateSessions(userID); err != nil {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
Can optionally provide a groupId string-like into session save/delete options. Listening for expiration coming in a future PR.

Also moves id back to hex-encoded strings.